### PR TITLE
A more specific error message for types without constructors

### DIFF
--- a/TestDataGenerator/TypeBuilder.cs
+++ b/TestDataGenerator/TypeBuilder.cs
@@ -86,7 +86,7 @@
 
             if (constructor == null)
             {
-                throw new InvalidOperationException("Unable to find a constructor");
+                throw new InvalidOperationException(string.Format("Unable to find a constructor for type '{0}'", type.FullName));
             }
 
             this.instanceCreator = () => InvokeConstructor(constructor);


### PR DESCRIPTION
I was having trouble determining which type in my graph was causing this problem. This error message helped me find the type that was missing a public constructor.
