### PR TITLE
Issue due to Max Recursion Dept is set to lower and instance is null

### DIFF
--- a/TestDataGenerator/Catalog.cs
+++ b/TestDataGenerator/Catalog.cs
@@ -120,8 +120,11 @@ namespace TestDataGenerator
                 }
 
                 object instance = builder.CreateInstance(type, name);
-
-                postCreationHandlers.ForEach(h => h.ApplyPostCreationRule(instance));
+                
+                if (instance != null)
+                {
+                    postCreationHandlers.ForEach(h => h.ApplyPostCreationRule(instance));
+                }
 
                 return instance;
             }

--- a/TestDataGenerator/TypeBuilder.cs
+++ b/TestDataGenerator/TypeBuilder.cs
@@ -129,9 +129,12 @@
 
             var instance = instanceCreator();
 
-            SetProperties(instance);
+            if (instance != null)
+            {
+                SetProperties(instance);
 
-            this.postConfiguration.ForEach(a => a(instance));
+                this.postConfiguration.ForEach(a => a(instance));
+            }
 
             return instance;
         }

--- a/TestDataGenerator/TypeBuilder.cs
+++ b/TestDataGenerator/TypeBuilder.cs
@@ -154,7 +154,10 @@
             foreach (var prop in props)
             {
                 object val = this.catalog.CreateInstance(prop.PropertyType, prop.Name);
-                prop.SetValue(instance, val, null);
+                if (val != null)
+                {
+                    prop.SetValue(instance, val, null);
+                }
             }
         }
 


### PR DESCRIPTION
Consider when we set the MaxRecursionDept = 3, then we were getting at instance as null on recursion 4. And due to which it is throwing exception while calling post Creation Handlers.
Please find the updated patch which will fix this issue.